### PR TITLE
fix file encoding and missing "\" after directory

### DIFF
--- a/v1/ImageEqual.ahk
+++ b/v1/ImageEqual.ahk
@@ -1,4 +1,4 @@
-#include ImagePut.ahk
+﻿#include ImagePut.ahk
 
 ImageEqual(images*) {
    return ImageEqual.call(images*)

--- a/v1/ImagePut.ahk
+++ b/v1/ImagePut.ahk
@@ -1,4 +1,4 @@
-; Script:    ImagePut.ahk
+﻿; Script:    ImagePut.ahk
 ; Author:    iseahound
 ; License:   MIT License
 ; Version:   2020-05-22
@@ -1297,7 +1297,7 @@ class ImagePut {
       SplitPath filepath,, directory, extension, filename
       filename := (filename != "") ? filename : "___date___"
       extension := (extension ~= "^(?i:bmp|dib|rle|jpg|jpeg|jpe|jfif|gif|tif|tiff|png)$") ? extension : "png"
-      filepath := directory . filename "." extension
+      filepath := directory . "\" . filename "." extension
 
       ; Fill a buffer with the available encoders.
       DllCall("gdiplus\GdipGetImageEncodersSize", "uint*", count:=0, "uint*", size:=0)
@@ -1348,8 +1348,8 @@ class ImagePut {
       if (filename == "___date___") {
          FileGetTime filename, % filepath
          FormatTime filename, % filename, % "yyyy-MM-dd HH꞉mm꞉ss"
-         FileMove % filepath, % directory . filename "." extension, true
-         filepath := directory . filename "." extension
+         FileMove % filepath, % directory . "\" . filename "." extension, true
+         filepath := directory . "\" . filename "." extension
       }
 
       return filepath

--- a/v2/ImageEqual.ahk
+++ b/v2/ImageEqual.ahk
@@ -1,4 +1,4 @@
-#include ImagePut.ahk
+﻿#include ImagePut.ahk
 
 ImageEqual(images*)
    => ImageEqual.call(images*)

--- a/v2/ImagePut.ahk
+++ b/v2/ImagePut.ahk
@@ -1,4 +1,4 @@
-; Script:    ImagePut.ahk
+﻿; Script:    ImagePut.ahk
 ; Author:    iseahound
 ; License:   MIT License
 ; Version:   2020-05-22
@@ -1297,7 +1297,7 @@ class ImagePut {
       SplitPath filepath,, directory, extension, filename
       filename := (filename != "") ? filename : "___date___"
       extension := (extension ~= "^(?i:bmp|dib|rle|jpg|jpeg|jpe|jfif|gif|tif|tiff|png)$") ? extension : "png"
-      filepath := directory . filename "." extension
+      filepath := directory . "\" . filename "." extension
 
       ; Fill a buffer with the available encoders.
       DllCall("gdiplus\GdipGetImageEncodersSize", "uint*", count:=0, "uint*", size:=0)
@@ -1348,8 +1348,8 @@ class ImagePut {
       if (filename == "___date___") {
          filename := FileGetTime(filepath)
          filename := FormatTime(filename, "yyyy-MM-dd HH꞉mm꞉ss")
-         FileMove(filepath, directory . filename "." extension, true)
-         filepath := directory . filename "." extension
+         FileMove(filepath, directory . "\" . filename "." extension, true)
+         filepath := directory . "\" . filename "." extension
       }
 
       return filepath


### PR DESCRIPTION
- Change file encoding from UTF-8 (Without BOM) to UTF-8 (With BOM), because of the use of unicode colon character `꞉`. AHK V2 seems can handle no-BOM file, but AHK V1 can't.
- Change all of `directory .` to `directory . "\" .`