### PR TITLE
Fix bug where focus search loop could go out of range

### DIFF
--- a/source/imagesearch2.c
+++ b/source/imagesearch2.c
@@ -18,7 +18,7 @@ unsigned int imagesearch2(unsigned int * restrict result, unsigned int * start, 
 
     // Try to locate the focused pixel in the middle of the sprite
     unsigned int * c = s + w/4 + h/4 * w;
-    unsigned int * last_pixel = s + w + h * w;
+    unsigned int * last_pixel = s + h * w;
     while(c < last_pixel) {
         for (unsigned int * e = c + w / 2; c < e; c++) {
             if ( *((unsigned char *) c + 3) ) {

--- a/source/imagesearchall2.c
+++ b/source/imagesearchall2.c
@@ -20,7 +20,7 @@ unsigned int imagesearchall2(unsigned int * restrict result, unsigned int capaci
 
     // Try to locate the focused pixel in the middle of the sprite
     unsigned int * c = s + w/4 + h/4 * w;
-    unsigned int * last_pixel = s + w + h * w;
+    unsigned int * last_pixel = s + h * w;
     while(c < last_pixel) {
         for (unsigned int * e = c + w / 2; c < e; c++) {
             if ( *((unsigned char *) c + 3) ) {


### PR DESCRIPTION
My bad.

As you noticed(https://github.com/iseahound/ImagePut/pull/36#issuecomment-1855899673), the expression should be simply "s + w * h" 