### PR TITLE
Add support for Windows 11 Explorer Tabs

### DIFF
--- a/ImagePut.ahk
+++ b/ImagePut.ahk
@@ -972,7 +972,7 @@ class ImagePut {
          if (offset := NumGet(ptr + pos + 4, "uint"))
             pos += offset + 8
          else break
-      return pos + 4 == size
+      return pos + 4 == size && !NumGet(ptr + pos, "uint") ; 4 byte null terminator
    }
 
    static IsImage(ptr, size) {


### PR DESCRIPTION
Hi!

I came across your repo yesterday since I was searching pasting clpiboard images into the explorer.
Great work!

On Windows 10 it works great but when I tried it on a Windows 11 PC with an Explorer with multiple tabs, the wrong "tab" was selected.

Here is a fix where the "active" Tab of the most recent explorer gets chosen (works for Windows 10 too since the explorer is built similarly 😂)