### PR TITLE
Avoid LocalSameAsGlobal Warnings in AHK v2 library

### DIFF
--- a/ImagePut.ahk
+++ b/ImagePut.ahk
@@ -1059,6 +1059,7 @@ class ImagePut {
    }
 
    static BitmapCrop(&pBitmap, crop) {
+      local format
       if not (IsObject(crop)
       && crop[1] ~= "^-?\d+(\.\d*)?%?$" && crop[2] ~= "^-?\d+(\.\d*)?%?$"
       && crop[3] ~= "^-?\d+(\.\d*)?%?$" && crop[4] ~= "^-?\d+(\.\d*)?%?$")
@@ -1121,6 +1122,7 @@ class ImagePut {
    }
 
    static BitmapScale(&pBitmap, scale, direction := 0, bound := "", outDimensions := "") {
+      local format
       ; min() specifies the greatest lower bound or the maximum size, fitting the image to the bounding box.
       ; max() specifies the least upper bound or the minimum size, filling the image to the bounding box.
       bound := HasMethod(bound) ? bound ; Custom function
@@ -2059,6 +2061,7 @@ class ImagePut {
    }
 
    static FileToStream(image) {
+      local file
       file := FileOpen(image, "r")
       file.pos := 0
       handle := DllCall("GlobalAlloc", "uint", 0x2, "uptr", file.length, "ptr")
@@ -2372,6 +2375,7 @@ class ImagePut {
    }
 
    static WICBitmapToBitmap(image) {
+      local format
       IWICBitmap := image
 
       ; Get Bitmap width and height.
@@ -3018,6 +3022,7 @@ class ImagePut {
       }
 
       Crop(x, y, w, h) {
+         local format
          DllCall("gdiplus\GdipGetImagePixelFormat", "ptr", this.pBitmap, "int*", &format:=0)
          DllCall("gdiplus\GdipCloneBitmapAreaI", "int", x, "int", y, "int", w, "int", h, "int", format, "ptr", this.pBitmap, "ptr*", &pBitmap:=0)
          try return ImagePut.BitmapToBuffer(pBitmap)
@@ -3881,6 +3886,7 @@ class ImagePut {
    }
 
    static Show(pBitmap, title:="", pos:="", style:="", styleEx:="", parent:="", playback:="", cache:="") {
+      local number, type
       ; Window Styles - https://docs.microsoft.com/en-us/windows/win32/winmsg/window-styles
       WS_POPUP                  := 0x80000000   ; Allow small windows.
       WS_VISIBLE                := 0x10000000   ; Show on creation.
@@ -4222,6 +4228,7 @@ class ImagePut {
       return cls
 
    WindowProc(hwnd, uMsg, wParam, lParam) {
+      local number
       static ll := A_ListLines
       ListLines 0
       ; (v2 only) Pass as a closure, otherwise hwnd := this would be needed.


### PR DESCRIPTION
This prevents warnings in the library for AHK v2 when #Warn LocalSameAsGlobal is set to On by defining the conflicting variables as local.